### PR TITLE
enable Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ install:
   - cd fonttools; python setup.py install; cd ..
   # MutatorMath
   - python setup.py install
+  - pip install coveralls
 script:
   - cd Lib/mutatorMath/test/ufo
   - python test.py | tee /dev/stderr | grep "\*\*\*Test Failed\*\*\*"; if [[ ${PIPESTATUS[2]} == "0" ]]; then exit 1 ; fi
+  - coverage run test.py
+after_success:
+  coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ install:
 script:
   - cd Lib/mutatorMath/test/ufo
   - python test.py | tee /dev/stderr | grep "\*\*\*Test Failed\*\*\*"; if [[ ${PIPESTATUS[2]} == "0" ]]; then exit 1 ; fi
-  - coverage run test.py
+  - coverage run --source=mutatorMath test.py
 after_success:
   coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/LettError/MutatorMath.svg)](https://travis-ci.org/LettError/MutatorMath)
+[![Build Status](https://travis-ci.org/LettError/MutatorMath.svg?branch=master)](https://travis-ci.org/LettError/MutatorMath)
+[![Coverage Status](https://coveralls.io/repos/LettError/MutatorMath/badge.svg?branch=master&service=github)](https://coveralls.io/github/LettError/MutatorMath?branch=master)
 
 MutatorMath
 ===========


### PR DESCRIPTION
@LettError this change is for enabling https://coveralls.io/ . It's a nice service for seeing which parts of the code are being hit by the test cases, which is the same to say that it provides a report on the code's coverage.

I find their UI somewhat unintuitive, but the data they provide is pretty good, I think. You can get a glimpse of it here https://coveralls.io/github/miguelsousa/MutatorMath

~~MutatorMath's overall score is rather low because of all of the dependencies. But if you filter the list of files by using the keyword **mutatorMath** you'll get a better sense of MM's current coverage. See image below.~~
<img width="1152" alt="screen shot 2015-09-25 at 09 57 30" src="https://cloud.githubusercontent.com/assets/2119742/10108280/e1b7bca4-6374-11e5-9c9b-c1809b51b6c8.png">

I'm planning to make another PR soon that will add on to the existing tests, so you can see how the coverage is affected.