### PR TITLE
ufo.document: don't use logging.basicConfig; only configure the 'mutatorMath' logger

### DIFF
--- a/Lib/mutatorMath/ufo/document.py
+++ b/Lib/mutatorMath/ufo/document.py
@@ -26,12 +26,15 @@ from mutatorMath.ufo.instance import InstanceWriter
 
 def newLogger(proposedLogPath):
     """ Create a new logging object at this path """
-    logging.basicConfig(filename=proposedLogPath,
-            level=logging.INFO,
-            filemode="w",
-            format='%(asctime)s MutatorMath %(message)s',
-            )
-    return logging.getLogger("mutatorMath")
+    logger = logging.getLogger("mutatorMath")
+    handler = logging.FileHandler(proposedLogPath, 'w')
+    formatter = logging.Formatter('%(asctime)s MutatorMath %(message)s')
+    handler.setFormatter(formatter)
+    for h in logger.handlers[:]:
+        logger.removeHandler(h)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger
 
 def _indent(elem, whitespace="    ", level=0):
     # taken from http://effbot.org/zone/element-lib.htm#prettyprint


### PR DESCRIPTION
The `logging.basicConfig` function configures the "root" logger, i.e. the parent of all loggers, so it also influences loggers from other libraries which are outside of the 'mutatorMath' logging namespace.

If you want to configure a default file handler for mutatorMath, then you should do it for the specific 'mutatorMath' logger only, and not for the global, root logger.

E.g., see: https://github.com/googlei18n/fontmake/pull/66

The `newLogger` function name implies it returns a new logging object. However, `logging.getLogger()` does not always return new logging objects, since loggers instances are 'singleton': i.e. they are created only once (identified by their name), and are cached in a global dict inside the `logging` module.

Anyway, here the `newLogger` function is only called once, so it does return a 'new' logger (unless a logger named 'mutatorMath' had already been created by someone else before, unlikely but not impossible...). If `newLogger` were to be called twice, the function would return the same instance -- possibly modified if given a different 'logPath' argument.