### PR TITLE
Removing robofab from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,11 @@ python:
 before_install:
   - git clone https://github.com/typesupply/defcon.git --branch ufo3
   - git clone https://github.com/typesupply/fontMath.git --branch ufo3
-  - git clone https://github.com/robofab-developers/robofab.git --branch ufo3k
   - git clone https://github.com/unified-font-object/ufoLib.git
   - git clone https://github.com/behdad/fonttools.git
 install:
   - cd defcon; python setup.py install; cd ..
   - cd fontMath; python setup.py install; cd ..
-  - cd robofab; python install.py; cd ..
   - cd fonttools; python setup.py install; cd ..
   - cd ufoLib; python setup.py install; cd ..
   # MutatorMath


### PR DESCRIPTION
Should not be necessary anymore, but CI will tell us if it all comes crumbling down.