### PR TITLE
process paths thru abspath()

### DIFF
--- a/Lib/mutatorMath/ufo/document.py
+++ b/Lib/mutatorMath/ufo/document.py
@@ -460,7 +460,7 @@ class DesignSpaceDocumentReader(object):
             # shall we just read the UFO here?
             filename = sourceElement.attrib.get('filename')
             # filename is a path relaive to the documentpath. resolve first.
-            sourcePath = os.path.join(os.path.dirname(self.path), filename)
+            sourcePath = os.path.abspath(os.path.join(os.path.dirname(self.path), filename))
             sourceName = sourceElement.attrib.get('name')
             self.reportProgress("prep", 'load', sourcePath)
             if not os.path.exists(sourcePath):

--- a/Lib/mutatorMath/ufo/instance.py
+++ b/Lib/mutatorMath/ufo/instance.py
@@ -382,7 +382,7 @@ class InstanceWriter(object):
             # remove glyph from groups / kerning as well?
             # remove components referencing this glyph?
         try:
-            self.font.save(self.path, self.ufoVersion)
+            self.font.save(os.path.abspath(self.path), self.ufoVersion)
         except defcon.DefconError as error:
             if self.logger:
                 self.logger.exception("Error generating.")


### PR DESCRIPTION
For context, I ran into two problems:

* **Source not found at [...]** from `ufo/document.py` line 467

The designspace file was in the system's temp directory, but the master fonts were in a totally different folder. The path looked something like this,
`/var/folders/9n/dmqv5kmj12l8xj5t7g_33dt80000gn/T/../../../../../Users/myself/Projects/master.ufo`

* **OSError: [Errno 13] Permission denied** from Python's `os.py`, via `ufo/instance.py` line 385.

The setup was the same as above. The path that made it fail looked something like this,
`/var/folders/9n/dmqv5kmj12l8xj5t7g_33dt80000gn/T/../../../../../Users/myself/Desktop/instance.ufo`