### PR TITLE
Add axes data to designspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Lib/support/mutatorMath-performance.py
 
 .coverage
 .coverage.*
+layerinfo.plist

--- a/Docs/designSpaceFileFormat.md
+++ b/Docs/designSpaceFileFormat.md
@@ -68,10 +68,10 @@ Both instance and source elements contain paths to files. These paths are expect
 				<!-- required: maximum value for axis -->
 				maximum="1000"
 				<!-- optional: default value for axis -->
-				initialvalue="96"
+				default="96"
 		/>
-			<!-- optional child element: avar table values, "warpmap"
-            <point input="<number>" output="<number>" />
+			<!-- optional child element: avar table values, "map"
+            <map input="<number>" output="<number>" />
         </axis>
 	</axes>
 

--- a/Docs/designSpaceFileFormat.md
+++ b/Docs/designSpaceFileFormat.md
@@ -56,7 +56,24 @@ Both instance and source elements contain paths to files. These paths are expect
 <?xml version="1.0" ?>
 <designspace format="3">
 
-
+	<!-- optional: list of axis elements -->
+	<axes>
+		<axis	
+				<!-- required: 4 letter axis tag see [ref] -->
+				tag="aaaa"
+				<!-- optional: human readable name -->
+				name="nice name for axis"
+				<!-- required: minimum value for axis -->
+				minimum="72"
+				<!-- required: maximum value for axis -->
+				maximum="1000"
+				<!-- optional: default value for axis -->
+				initialvalue="96"
+		/>
+			<!-- optional child element: avar table values, "warpmap"
+            <point input="<number>" output="<number>" />
+        </axis>
+	</axes>
 
 	<!-- required: one sources element -->
 	<sources>
@@ -160,6 +177,9 @@ Both instance and source elements contain paths to files. These paths are expect
 
 </designspace>
 ```
+
+## The axis element
+
 
 ## The source element
 

--- a/Docs/designSpaceFileFormat.md
+++ b/Docs/designSpaceFileFormat.md
@@ -59,7 +59,7 @@ Both instance and source elements contain paths to files. These paths are expect
 	<!-- optional: list of axis elements -->
 	<axes>
 		<axis	
-				<!-- required: 4 letter axis tag see [ref] -->
+				<!-- required: 4 letter axis tag see OpenType axis tags -->
 				tag="aaaa"
 				<!-- optional: human readable name -->
 				name="nice name for axis"

--- a/Lib/mutatorMath/objects/bender.py
+++ b/Lib/mutatorMath/objects/bender.py
@@ -37,14 +37,18 @@ class WarpMutator(mutatorMath.objects.mutator.Mutator):
 class Bender(object):
     # object with a dictionary of warpmaps
     # call instance with a location to bend it
-    def __init__(self, warpDict):
+    def __init__(self, axes):
+        # axes dict:
+        #   { <axisname>: {'warp':[], 'minimum':0, 'maximum':1000, 'initial':0, 'tag':'aaaa', 'name':"longname"}}
+        warpDict = {}
+        for axisName, axisAttributes in axes.items():
+            warpDict[axisName] = axisAttributes.get('warp', [])
         self.warps = {}
         self.maps = {}    # not needed?
         for axisName, obj in warpDict.items():
             if type(obj)==list:
                 self._makeWarpFromList(axisName, obj)
             elif hasattr(obj, '__call__'):
-                # self.warps[axisName] = WarpFunctionWrapper(obj)
                 self.warps[axisName] = obj
     
     def getMap(self, axisName):
@@ -96,32 +100,33 @@ class Bender(object):
         return new
 
 if __name__ == "__main__":
-
     # no bender
     assert noBend(Location(a=1234)) == Location(a=1234)
 
     # linear map, single axis
-    w = {'a': [(0, 0), (1000, 1000)]}
+    w = {'aaaa':{'warp': [(0, 0), (1000, 1000)], 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'initital':0}}
     b = Bender(w)
-    assert b(Location(a=0)) == Location(a=0)
-    assert b(Location(a=500)) == Location(a=500)
-    assert b(Location(a=1000)) == Location(a=1000)
+    assert b(Location(aaaa=0)) == Location(aaaa=0)
+    assert b(Location(aaaa=500)) == Location(aaaa=500)
+    assert b(Location(aaaa=1000)) == Location(aaaa=1000)
 
     # linear map, single axis
-    w = {'a': [(0, 100), (1000, 900)]}
+    #w = {'a': [(0, 100), (1000, 900)]}
+    w = {'aaaa':{'warp': [(0, 100), (1000, 900)], 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'initital':0}}
     b = Bender(w)
-    assert b(Location(a=0)) == Location(a=100)
-    assert b(Location(a=500)) == Location(a=500)
-    assert b(Location(a=1000)) == Location(a=900)
+    assert b(Location(aaaa=0)) == Location(aaaa=100)
+    assert b(Location(aaaa=500)) == Location(aaaa=500)
+    assert b(Location(aaaa=1000)) == Location(aaaa=900)
 
     # one split map, single axis
-    w = {'a': [(0, 0), (500, 200), (1000, 1000)]}
+    #w = {'a': [(0, 0), (500, 200), (1000, 1000)]}
+    w = {'aaaa':{'warp': [(0, 0), (500, 200), (1000, 1000)], 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'initital':0}}
     b = Bender(w)
-    assert b(Location(a=0)) == Location(a=0)
-    assert b(Location(a=250)) == Location(a=100)
-    assert b(Location(a=500)) == Location(a=200)
-    assert b(Location(a=750)) == Location(a=600)
-    assert b(Location(a=1000)) == Location(a=1000)
+    assert b(Location(aaaa=0)) == Location(aaaa=0)
+    assert b(Location(aaaa=250)) == Location(aaaa=100)
+    assert b(Location(aaaa=500)) == Location(aaaa=200)
+    assert b(Location(aaaa=750)) == Location(aaaa=600)
+    assert b(Location(aaaa=1000)) == Location(aaaa=1000)
 
     # now with warp functions
     def warpFunc_1(value):
@@ -131,17 +136,22 @@ if __name__ == "__main__":
     def warpFunc_Error(value):
         return 1/0
 
-    w = {'a': warpFunc_1, 'b': warpFunc_2, 'c': warpFunc_Error}
+    w = {   'aaaa':{'warp': warpFunc_1, 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'initital':0},
+            'bbbb':{'warp': warpFunc_2, 'name':'bbbbAxis', 'tag':'bbbb', 'minimum':0, 'maximum':1000, 'initital':0},
+            'bbbb':{'warp': warpFunc_2, 'name':'bbbbAxis', 'tag':'bbbb', 'minimum':0, 'maximum':1000, 'initital':0},
+        }
+    # w = {'a': warpFunc_1, 'b': warpFunc_2, 'c': warpFunc_Error}
     b = Bender(w)
-    assert b(Location(a=100)) == Location(a=200)
-    assert b(Location(b=100)) == Location(b=10000)
+    assert b(Location(aaaa=100)) == Location(aaaa=200)
+    assert b(Location(bbbb=100)) == Location(bbbb=10000)
 
-    # see if the errors are caught and reported:
+    # # see if the errors are caught and reported:
     try:
         b(Location(c=-1))
     except:
         ex_type, ex, tb = sys.exc_info()
         err = 'A warpfunction "warpFunc_Error" (for axis "c") raised "integer division or modulo by zero" at location c:-1'
+        print err
         assert ex.msg == err
 
 

--- a/Lib/mutatorMath/objects/bender.py
+++ b/Lib/mutatorMath/objects/bender.py
@@ -151,7 +151,6 @@ if __name__ == "__main__":
     except:
         ex_type, ex, tb = sys.exc_info()
         err = 'A warpfunction "warpFunc_Error" (for axis "c") raised "integer division or modulo by zero" at location c:-1'
-        print err
         assert ex.msg == err
 
 

--- a/Lib/mutatorMath/objects/bender.py
+++ b/Lib/mutatorMath/objects/bender.py
@@ -138,7 +138,6 @@ if __name__ == "__main__":
 
     w = {   'aaaa':{'warp': warpFunc_1, 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'initital':0},
             'bbbb':{'warp': warpFunc_2, 'name':'bbbbAxis', 'tag':'bbbb', 'minimum':0, 'maximum':1000, 'initital':0},
-            'bbbb':{'warp': warpFunc_2, 'name':'bbbbAxis', 'tag':'bbbb', 'minimum':0, 'maximum':1000, 'initital':0},
         }
     # w = {'a': warpFunc_1, 'b': warpFunc_2, 'c': warpFunc_Error}
     b = Bender(w)

--- a/Lib/mutatorMath/objects/bender.py
+++ b/Lib/mutatorMath/objects/bender.py
@@ -39,7 +39,7 @@ class Bender(object):
     # call instance with a location to bend it
     def __init__(self, axes):
         # axes dict:
-        #   { <axisname>: {'warp':[], 'minimum':0, 'maximum':1000, 'initial':0, 'tag':'aaaa', 'name':"longname"}}
+        #   { <axisname>: {'warp':[], 'minimum':0, 'maximum':1000, 'default':0, 'tag':'aaaa', 'name':"longname"}}
         warpDict = {}
         for axisName, axisAttributes in axes.items():
             warpDict[axisName] = axisAttributes.get('warp', [])
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     assert noBend(Location(a=1234)) == Location(a=1234)
 
     # linear map, single axis
-    w = {'aaaa':{'warp': [(0, 0), (1000, 1000)], 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'initital':0}}
+    w = {'aaaa':{'warp': [(0, 0), (1000, 1000)], 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'default':0}}
     b = Bender(w)
     assert b(Location(aaaa=0)) == Location(aaaa=0)
     assert b(Location(aaaa=500)) == Location(aaaa=500)
@@ -112,7 +112,7 @@ if __name__ == "__main__":
 
     # linear map, single axis
     #w = {'a': [(0, 100), (1000, 900)]}
-    w = {'aaaa':{'warp': [(0, 100), (1000, 900)], 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'initital':0}}
+    w = {'aaaa':{'warp': [(0, 100), (1000, 900)], 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'default':0}}
     b = Bender(w)
     assert b(Location(aaaa=0)) == Location(aaaa=100)
     assert b(Location(aaaa=500)) == Location(aaaa=500)
@@ -120,7 +120,7 @@ if __name__ == "__main__":
 
     # one split map, single axis
     #w = {'a': [(0, 0), (500, 200), (1000, 1000)]}
-    w = {'aaaa':{'warp': [(0, 0), (500, 200), (1000, 1000)], 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'initital':0}}
+    w = {'aaaa':{'warp': [(0, 0), (500, 200), (1000, 1000)], 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'default':0}}
     b = Bender(w)
     assert b(Location(aaaa=0)) == Location(aaaa=0)
     assert b(Location(aaaa=250)) == Location(aaaa=100)
@@ -136,8 +136,8 @@ if __name__ == "__main__":
     def warpFunc_Error(value):
         return 1/0
 
-    w = {   'aaaa':{'warp': warpFunc_1, 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'initital':0},
-            'bbbb':{'warp': warpFunc_2, 'name':'bbbbAxis', 'tag':'bbbb', 'minimum':0, 'maximum':1000, 'initital':0},
+    w = {   'aaaa':{'warp': warpFunc_1, 'name':'aaaaAxis', 'tag':'aaaa', 'minimum':0, 'maximum':1000, 'default':0},
+            'bbbb':{'warp': warpFunc_2, 'name':'bbbbAxis', 'tag':'bbbb', 'minimum':0, 'maximum':1000, 'default':0},
         }
     # w = {'a': warpFunc_1, 'b': warpFunc_2, 'c': warpFunc_Error}
     b = Bender(w)

--- a/Lib/mutatorMath/objects/mutator.py
+++ b/Lib/mutatorMath/objects/mutator.py
@@ -13,15 +13,15 @@ _EPSILON = sys.float_info.epsilon
 
 def noBend(loc): return loc
 
-def buildMutator(items, warpDict=None):
+def buildMutator(items, axes=None):
     """
         Build a mutator with the (location, obj) pairs in items.
         Determine the bias based on the given locations.
     """
     from mutatorMath.objects.bender import Bender
     m = Mutator()
-    if warpDict is not None:
-        bender = Bender(warpDict)
+    if axes is not None:
+        bender = Bender(axes)
         m.setBender(bender)
     else:
         bender = noBend

--- a/Lib/mutatorMath/test/ufo/data/axes_test.designspace
+++ b/Lib/mutatorMath/test/ufo/data/axes_test.designspace
@@ -4,15 +4,15 @@
         <axis initial="0" maximum="1000" minimum="-1000" name="weight" tag="wght">
             <point input="0" output="100.0" />
             <point input="100" output="155.0" />
-            <point input="200" output="240.25" />
-            <point input="300" output="372.3875" />
-            <point input="400" output="577.200625" />
-            <point input="500" output="894.66096875" />
-            <point input="600" output="1386.72450156" />
-            <point input="700" output="2149.42297742" />
-            <point input="800" output="3331.605615" />
-            <point input="900" output="5163.98870326" />
-            <point input="1000" output="8004.18249005" />
+            <point input="200" output="240.0" />
+            <point input="300" output="372.0" />
+            <point input="400" output="577.0" />
+            <point input="500" output="895.0" />
+            <point input="600" output="1387.0" />
+            <point input="700" output="2149.0" />
+            <point input="800" output="3332.0" />
+            <point input="900" output="5164.0" />
+            <point input="1000" output="8004.0" />
         </axis>
         <axis initial="0" maximum="1000" minimum="0" name="width" tag="wdth" />
     </axes>

--- a/Lib/mutatorMath/test/ufo/data/axes_test.designspace
+++ b/Lib/mutatorMath/test/ufo/data/axes_test.designspace
@@ -1,20 +1,20 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
     <axes>
-        <axis initial="0" maximum="1000" minimum="-1000" name="weight" tag="wght">
-            <point input="0" output="100.0" />
-            <point input="100" output="155.0" />
-            <point input="200" output="240.0" />
-            <point input="300" output="372.0" />
-            <point input="400" output="577.0" />
-            <point input="500" output="895.0" />
-            <point input="600" output="1387.0" />
-            <point input="700" output="2149.0" />
-            <point input="800" output="3332.0" />
-            <point input="900" output="5164.0" />
-            <point input="1000" output="8004.0" />
+        <axis default="0" maximum="1000" minimum="-1000" name="weight" tag="wght">
+            <map input="0" output="100.0" />
+            <map input="100" output="155.0" />
+            <map input="200" output="240.0" />
+            <map input="300" output="372.0" />
+            <map input="400" output="577.0" />
+            <map input="500" output="895.0" />
+            <map input="600" output="1387.0" />
+            <map input="700" output="2149.0" />
+            <map input="800" output="3332.0" />
+            <map input="900" output="5164.0" />
+            <map input="1000" output="8004.0" />
         </axis>
-        <axis initial="0" maximum="1000" minimum="0" name="width" tag="wdth" />
+        <axis default="0" maximum="1000" minimum="0" name="width" tag="wdth" />
     </axes>
     <sources />
     <instances />

--- a/Lib/mutatorMath/test/ufo/data/axes_test.designspace
+++ b/Lib/mutatorMath/test/ufo/data/axes_test.designspace
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="3">
+    <axes>
+        <axis initial="0" maximum="1000" minimum="-1000" name="weight" tag="wght">
+            <point input="0" output="100.0" />
+            <point input="100" output="155.0" />
+            <point input="200" output="240.25" />
+            <point input="300" output="372.3875" />
+            <point input="400" output="577.200625" />
+            <point input="500" output="894.66096875" />
+            <point input="600" output="1386.72450156" />
+            <point input="700" output="2149.42297742" />
+            <point input="800" output="3331.605615" />
+            <point input="900" output="5163.98870326" />
+            <point input="1000" output="8004.18249005" />
+        </axis>
+        <axis initial="0" maximum="1000" minimum="0" name="width" tag="wdth" />
+    </axes>
+    <sources />
+    <instances />
+</designspace>

--- a/Lib/mutatorMath/test/ufo/data/exporttest_basic.designspace
+++ b/Lib/mutatorMath/test/ufo/data/exporttest_basic.designspace
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
+    <axes />
     <sources>
         <source familyname="ExplicitSourceFamilyName" filename="sources/light/LightCondensed.ufo" name="master_1" stylename="ExplicitSourceStyleName">
             <lib copy="1" />

--- a/Lib/mutatorMath/test/ufo/data/exporttest_build.designspace
+++ b/Lib/mutatorMath/test/ufo/data/exporttest_build.designspace
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
+    <axes />
     <sources>
         <source filename="sources/light/LightCondensed.ufo" name="master_1">
             <lib copy="1" />

--- a/Lib/mutatorMath/test/ufo/data/exporttest_info.designspace
+++ b/Lib/mutatorMath/test/ufo/data/exporttest_info.designspace
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
+    <axes />
     <sources>
         <source filename="sources/light/LightCondensed.ufo" name="master_1">
             <info copy="1" />

--- a/Lib/mutatorMath/test/ufo/data/exporttest_kerning.designspace
+++ b/Lib/mutatorMath/test/ufo/data/exporttest_kerning.designspace
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
+    <axes />
     <sources>
         <source filename="sources/light/LightCondensed.ufo" name="master_1">
             <lib copy="1" />

--- a/Lib/mutatorMath/test/ufo/data/exporttest_kerning_muted.designspace
+++ b/Lib/mutatorMath/test/ufo/data/exporttest_kerning_muted.designspace
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
+    <axes />
     <sources>
         <source filename="sources/light/LightCondensed.ufo" name="master_1">
             <lib copy="1" />

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/fontinfo.plist
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/fontinfo.plist
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ascender</key>
+	<integer>750</integer>
+	<key>capHeight</key>
+	<integer>750</integer>
+	<key>descender</key>
+	<integer>-250</integer>
 	<key>familyName</key>
 	<string>TestFamily</string>
 	<key>postscriptBlueValues</key>
@@ -24,5 +30,9 @@
 	</array>
 	<key>styleName</key>
 	<string>TestStyleName</string>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>xHeight</key>
+	<integer>500</integer>
 </dict>
 </plist>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0050.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0050.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0050" format="1">
-  <advance width="60"/>
+  <advance width="79"/>
   <outline>
     <contour>
-      <point x="40" y="0" type="line"/>
-      <point x="40" y="300" type="line"/>
-      <point x="20" y="300" type="line"/>
+      <point x="59" y="0" type="line"/>
+      <point x="59" y="315" type="line"/>
+      <point x="20" y="315" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0100.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0100.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0100" format="1">
-  <advance width="61"/>
+  <advance width="98"/>
   <outline>
     <contour>
-      <point x="41" y="0" type="line"/>
-      <point x="41" y="301" type="line"/>
-      <point x="20" y="301" type="line"/>
+      <point x="78" y="0" type="line"/>
+      <point x="78" y="330" type="line"/>
+      <point x="20" y="330" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0150.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0150.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0150" format="1">
-  <advance width="64"/>
+  <advance width="117"/>
   <outline>
     <contour>
-      <point x="44" y="0" type="line"/>
-      <point x="44" y="303" type="line"/>
-      <point x="20" y="303" type="line"/>
+      <point x="97" y="0" type="line"/>
+      <point x="97" y="345" type="line"/>
+      <point x="20" y="345" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0200.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0200.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0200" format="1">
-  <advance width="67"/>
+  <advance width="136"/>
   <outline>
     <contour>
-      <point x="47" y="0" type="line"/>
-      <point x="47" y="306" type="line"/>
-      <point x="20" y="306" type="line"/>
+      <point x="116" y="0" type="line"/>
+      <point x="116" y="360" type="line"/>
+      <point x="20" y="360" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0250.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0250.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0250" format="1">
-  <advance width="72"/>
+  <advance width="155"/>
   <outline>
     <contour>
-      <point x="52" y="0" type="line"/>
-      <point x="52" y="309" type="line"/>
-      <point x="20" y="309" type="line"/>
+      <point x="135" y="0" type="line"/>
+      <point x="135" y="375" type="line"/>
+      <point x="20" y="375" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0300.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0300.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0300" format="1">
-  <advance width="77"/>
+  <advance width="174"/>
   <outline>
     <contour>
-      <point x="57" y="0" type="line"/>
-      <point x="57" y="313" type="line"/>
-      <point x="20" y="313" type="line"/>
+      <point x="154" y="0" type="line"/>
+      <point x="154" y="390" type="line"/>
+      <point x="20" y="390" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0350.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0350.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0350" format="1">
-  <advance width="84"/>
+  <advance width="193"/>
   <outline>
     <contour>
-      <point x="64" y="0" type="line"/>
-      <point x="64" y="319" type="line"/>
-      <point x="20" y="319" type="line"/>
+      <point x="173" y="0" type="line"/>
+      <point x="173" y="405" type="line"/>
+      <point x="20" y="405" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0400.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0400.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0400" format="1">
-  <advance width="92"/>
+  <advance width="212"/>
   <outline>
     <contour>
-      <point x="72" y="0" type="line"/>
-      <point x="72" y="325" type="line"/>
-      <point x="20" y="325" type="line"/>
+      <point x="192" y="0" type="line"/>
+      <point x="192" y="420" type="line"/>
+      <point x="20" y="420" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0450.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0450.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0450" format="1">
-  <advance width="104"/>
+  <advance width="231"/>
   <outline>
     <contour>
-      <point x="84" y="0" type="line"/>
-      <point x="84" y="335" type="line"/>
-      <point x="20" y="335" type="line"/>
+      <point x="211" y="0" type="line"/>
+      <point x="211" y="435" type="line"/>
+      <point x="20" y="435" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0500.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0500.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0500" format="1">
-  <advance width="116"/>
+  <advance width="250"/>
   <outline>
     <contour>
-      <point x="96" y="0" type="line"/>
-      <point x="96" y="344" type="line"/>
-      <point x="20" y="344" type="line"/>
+      <point x="230" y="0" type="line"/>
+      <point x="230" y="450" type="line"/>
+      <point x="20" y="450" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0550.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0550.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0550" format="1">
-  <advance width="134"/>
+  <advance width="269"/>
   <outline>
     <contour>
-      <point x="114" y="0" type="line"/>
-      <point x="114" y="358" type="line"/>
-      <point x="20" y="358" type="line"/>
+      <point x="249" y="0" type="line"/>
+      <point x="249" y="465" type="line"/>
+      <point x="20" y="465" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0600.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0600.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0600" format="1">
-  <advance width="152"/>
+  <advance width="288"/>
   <outline>
     <contour>
-      <point x="132" y="0" type="line"/>
-      <point x="132" y="373" type="line"/>
-      <point x="20" y="373" type="line"/>
+      <point x="268" y="0" type="line"/>
+      <point x="268" y="480" type="line"/>
+      <point x="20" y="480" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0650.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0650.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0650" format="1">
-  <advance width="180"/>
+  <advance width="307"/>
   <outline>
     <contour>
-      <point x="160" y="0" type="line"/>
-      <point x="160" y="395" type="line"/>
-      <point x="20" y="395" type="line"/>
+      <point x="287" y="0" type="line"/>
+      <point x="287" y="495" type="line"/>
+      <point x="20" y="495" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0700.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0700.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0700" format="1">
-  <advance width="209"/>
+  <advance width="326"/>
   <outline>
     <contour>
-      <point x="189" y="0" type="line"/>
-      <point x="189" y="417" type="line"/>
-      <point x="20" y="417" type="line"/>
+      <point x="306" y="0" type="line"/>
+      <point x="306" y="510" type="line"/>
+      <point x="20" y="510" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0750.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0750.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0750" format="1">
-  <advance width="253"/>
+  <advance width="345"/>
   <outline>
     <contour>
-      <point x="233" y="0" type="line"/>
-      <point x="233" y="452" type="line"/>
-      <point x="20" y="452" type="line"/>
+      <point x="325" y="0" type="line"/>
+      <point x="325" y="525" type="line"/>
+      <point x="20" y="525" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0800.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0800.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0800" format="1">
-  <advance width="297"/>
+  <advance width="364"/>
   <outline>
     <contour>
-      <point x="277" y="0" type="line"/>
-      <point x="277" y="487" type="line"/>
-      <point x="20" y="487" type="line"/>
+      <point x="344" y="0" type="line"/>
+      <point x="344" y="540" type="line"/>
+      <point x="20" y="540" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0850.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0850.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0850" format="1">
-  <advance width="365"/>
+  <advance width="383"/>
   <outline>
     <contour>
-      <point x="345" y="0" type="line"/>
-      <point x="345" y="540" type="line"/>
-      <point x="20" y="540" type="line"/>
+      <point x="363" y="0" type="line"/>
+      <point x="363" y="555" type="line"/>
+      <point x="20" y="555" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0900.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0900.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0900" format="1">
-  <advance width="433"/>
+  <advance width="402"/>
   <outline>
     <contour>
-      <point x="413" y="0" type="line"/>
-      <point x="413" y="594" type="line"/>
-      <point x="20" y="594" type="line"/>
+      <point x="382" y="0" type="line"/>
+      <point x="382" y="570" type="line"/>
+      <point x="20" y="570" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0950.glif
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/I_.0950.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="I.0950" format="1">
-  <advance width="538"/>
+  <advance width="421"/>
   <outline>
     <contour>
-      <point x="518" y="0" type="line"/>
-      <point x="518" y="677" type="line"/>
-      <point x="20" y="677" type="line"/>
+      <point x="401" y="0" type="line"/>
+      <point x="401" y="585" type="line"/>
+      <point x="20" y="585" type="line"/>
       <point x="20" y="0" type="line"/>
     </contour>
   </outline>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/contents.plist
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/glyphs/contents.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>I</key>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/lib.plist
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/lib.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>com.typemytype.robofont.background.layerStrokeColor</key>
@@ -32,17 +32,35 @@
 	<key>com.typemytype.robofont.sort</key>
 	<array>
 		<dict>
-			<key>ascending</key>
-			<array>
-				<string>I</string>
-			</array>
+			<key>allowPseudoUnicode</key>
+			<true/>
 			<key>type</key>
-			<string>glyphList</string>
+			<string>cannedDesign</string>
 		</dict>
 	</array>
 	<key>public.glyphOrder</key>
 	<array>
 		<string>I</string>
+		<string>I.0000</string>
+		<string>I.0050</string>
+		<string>I.0100</string>
+		<string>I.0150</string>
+		<string>I.0200</string>
+		<string>I.0250</string>
+		<string>I.0300</string>
+		<string>I.0350</string>
+		<string>I.0400</string>
+		<string>I.0450</string>
+		<string>I.0500</string>
+		<string>I.0550</string>
+		<string>I.0600</string>
+		<string>I.0650</string>
+		<string>I.0700</string>
+		<string>I.0750</string>
+		<string>I.0800</string>
+		<string>I.0850</string>
+		<string>I.0900</string>
+		<string>I.0950</string>
 	</array>
 </dict>
 </plist>

--- a/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/metainfo.plist
+++ b/Lib/mutatorMath/test/ufo/data/instances/W/StemOutput.ufo/metainfo.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>creator</key>

--- a/Lib/mutatorMath/test/ufo/data/warpmap_test.designspace
+++ b/Lib/mutatorMath/test/ufo/data/warpmap_test.designspace
@@ -1,5 +1,20 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
+    <axes>
+        <axis initial="0" maximum="1000" minimum="0" name="weight" tag="wght">
+            <point input="0" output="100.0" />
+            <point input="100" output="155.0" />
+            <point input="200" output="240.25" />
+            <point input="300" output="372.3875" />
+            <point input="400" output="577.200625" />
+            <point input="500" output="894.66096875" />
+            <point input="600" output="1386.72450156" />
+            <point input="700" output="2149.42297742" />
+            <point input="800" output="3331.605615" />
+            <point input="900" output="5163.98870326" />
+            <point input="1000" output="8004.18249005" />
+        </axis>
+    </axes>
     <sources>
         <source filename="sources/stems/StemThin.ufo" name="master_1">
             <lib copy="1" />
@@ -366,19 +381,4 @@
             </glyphs>
         </instance>
     </instances>
-    <warp>
-        <axis name="weight">
-            <point input="0" output="100.0" />
-            <point input="100" output="155.0" />
-            <point input="200" output="240.25" />
-            <point input="300" output="372.3875" />
-            <point input="400" output="577.200625" />
-            <point input="500" output="894.66096875" />
-            <point input="600" output="1386.72450156" />
-            <point input="700" output="2149.42297742" />
-            <point input="800" output="3331.605615" />
-            <point input="900" output="5163.98870326" />
-            <point input="1000" output="8004.18249005" />
-        </axis>
-    </warp>
 </designspace>

--- a/Lib/mutatorMath/test/ufo/data/warpmap_test.designspace
+++ b/Lib/mutatorMath/test/ufo/data/warpmap_test.designspace
@@ -4,15 +4,15 @@
         <axis initial="0" maximum="1000" minimum="0" name="weight" tag="wght">
             <point input="0" output="100.0" />
             <point input="100" output="155.0" />
-            <point input="200" output="240.25" />
-            <point input="300" output="372.3875" />
-            <point input="400" output="577.200625" />
-            <point input="500" output="894.66096875" />
-            <point input="600" output="1386.72450156" />
-            <point input="700" output="2149.42297742" />
-            <point input="800" output="3331.605615" />
-            <point input="900" output="5163.98870326" />
-            <point input="1000" output="8004.18249005" />
+            <point input="200" output="240.0" />
+            <point input="300" output="372.0" />
+            <point input="400" output="577.0" />
+            <point input="500" output="895.0" />
+            <point input="600" output="1387.0" />
+            <point input="700" output="2149.0" />
+            <point input="800" output="3332.0" />
+            <point input="900" output="5164.0" />
+            <point input="1000" output="8004.0" />
         </axis>
     </axes>
     <sources>

--- a/Lib/mutatorMath/test/ufo/data/warpmap_test.designspace
+++ b/Lib/mutatorMath/test/ufo/data/warpmap_test.designspace
@@ -1,18 +1,18 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
     <axes>
-        <axis initial="0" maximum="1000" minimum="0" name="weight" tag="wght">
-            <point input="0" output="100.0" />
-            <point input="100" output="155.0" />
-            <point input="200" output="240.0" />
-            <point input="300" output="372.0" />
-            <point input="400" output="577.0" />
-            <point input="500" output="895.0" />
-            <point input="600" output="1387.0" />
-            <point input="700" output="2149.0" />
-            <point input="800" output="3332.0" />
-            <point input="900" output="5164.0" />
-            <point input="1000" output="8004.0" />
+        <axis default="0" maximum="1000" minimum="0" name="weight" tag="wght">
+            <map input="0" output="100.0" />
+            <map input="100" output="155.0" />
+            <map input="200" output="240.0" />
+            <map input="300" output="372.0" />
+            <map input="400" output="577.0" />
+            <map input="500" output="895.0" />
+            <map input="600" output="1387.0" />
+            <map input="700" output="2149.0" />
+            <map input="800" output="3332.0" />
+            <map input="900" output="5164.0" />
+            <map input="1000" output="8004.0" />
         </axis>
     </axes>
     <sources>

--- a/Lib/mutatorMath/test/ufo/test.py
+++ b/Lib/mutatorMath/test/ufo/test.py
@@ -294,7 +294,7 @@ if __name__ == "__main__":
         >>> documentPath = os.path.join(testRoot, 'warpmap_test.designspace')
         >>> doc = DesignSpaceDocumentWriter(documentPath, verbose=True)
         >>> def grow(base, factor, steps):
-        ...     return [(i*100, base*(1+factor)**i) for i in range(steps)]
+        ...     return [(i*100, round(base*(1+factor)**i)) for i in range(steps)]
         >>> doc.addAxis("wght", "weight", 0, 1000, 0, grow(100,0.55,11))
         >>> doc.addSource(
         ...        os.path.join(sourcePath, "stems", "StemThin.ufo"),
@@ -338,10 +338,14 @@ if __name__ == "__main__":
         >>> documentPath = os.path.join(testRoot, 'axes_test.designspace')
         >>> doc = DesignSpaceDocumentWriter(documentPath, verbose=True)
         >>> def grow(base, factor, steps):
-        ...     return [(i*100, base*(1+factor)**i) for i in range(steps)]
+        ...     return [(i*100, round(base*(1+factor)**i)) for i in range(steps)]
 
         >>> # axis with a warp map
-        >>> doc.addAxis("wght", "weight", -1000, 1000, 0, grow(100,0.55,11))
+        >>> warpMap = grow(100,0.55,11)
+        >>> warpMap
+        [(0, 100.0), (100, 155.0), (200, 240.0), (300, 372.0), (400, 577.0), (500, 895.0), (600, 1387.0), (700, 2149.0), (800, 3332.0), (900, 5164.0), (1000, 8004.0)]
+
+        >>> doc.addAxis("wght", "weight", -1000, 1000, 0, warpMap)
         >>> # axis without a warp map
         >>> doc.addAxis("wdth", "width", 0, 1000, 0)
         >>> doc.save()
@@ -355,15 +359,15 @@ if __name__ == "__main__":
                     'tag': 'wght',
                     'warp': [(0.0, 100.0),
                              (100.0, 155.0),
-                             (200.0, 240.25),
-                             (300.0, 372.3875),
-                             (400.0, 577.200625),
-                             (500.0, 894.66096875),
-                             (600.0, 1386.72450156),
-                             (700.0, 2149.42297742),
-                             (800.0, 3331.605615),
-                             (900.0, 5163.98870326),
-                             (1000.0, 8004.18249005)]},
+                             (200.0, 240.0),
+                             (300.0, 372.0),
+                             (400.0, 577.0),
+                             (500.0, 895.0),
+                             (600.0, 1387.0),
+                             (700.0, 2149.0),
+                             (800.0, 3332.0),
+                             (900.0, 5164.0),
+                             (1000.0, 8004.0)]},
          'width': {'initial': 0.0,
                    'maximum': 1000.0,
                    'minimum': 0.0,

--- a/Lib/mutatorMath/test/ufo/test.py
+++ b/Lib/mutatorMath/test/ufo/test.py
@@ -290,14 +290,12 @@ if __name__ == "__main__":
         >>> ufoRelPath
         'data/instances/A/testOutput_glyphs.ufo'
 
-
-
-        # test the warp elements
+        # test the axes elements
         >>> documentPath = os.path.join(testRoot, 'warpmap_test.designspace')
         >>> doc = DesignSpaceDocumentWriter(documentPath, verbose=True)
         >>> def grow(base, factor, steps):
         ...     return [(i*100, base*(1+factor)**i) for i in range(steps)]
-        >>> doc.writeWarp({'weight':grow(100,0.55,11)})
+        >>> doc.addAxis("wght", "weight", 0, 1000, 0, grow(100,0.55,11))
         >>> doc.addSource(
         ...        os.path.join(sourcePath, "stems", "StemThin.ufo"),
         ...        name="master_1", 
@@ -335,6 +333,45 @@ if __name__ == "__main__":
         >>> doc = DesignSpaceDocumentReader(documentPath, ufoVersion, roundGeometry=roundGeometry, verbose=True, logPath=logPath)
         >>> doc.process(makeGlyphs=True, makeKerning=False, makeInfo=False)
 
+        # test the axes element
+        >>> from pprint import pprint
+        >>> documentPath = os.path.join(testRoot, 'axes_test.designspace')
+        >>> doc = DesignSpaceDocumentWriter(documentPath, verbose=True)
+        >>> def grow(base, factor, steps):
+        ...     return [(i*100, base*(1+factor)**i) for i in range(steps)]
+
+        >>> # axis with a warp map
+        >>> doc.addAxis("wght", "weight", -1000, 1000, 0, grow(100,0.55,11))
+        >>> # axis without a warp map
+        >>> doc.addAxis("wdth", "width", 0, 1000, 0)
+        >>> doc.save()
+
+        >>> doc = DesignSpaceDocumentReader(documentPath, ufoVersion, roundGeometry=roundGeometry, verbose=True, logPath=logPath)
+        >>> pprint(doc.axes)
+        {'weight': {'initial': 0.0,
+                    'maximum': 1000.0,
+                    'minimum': -1000.0,
+                    'name': 'weight',
+                    'tag': 'wght',
+                    'warp': [(0.0, 100.0),
+                             (100.0, 155.0),
+                             (200.0, 240.25),
+                             (300.0, 372.3875),
+                             (400.0, 577.200625),
+                             (500.0, 894.66096875),
+                             (600.0, 1386.72450156),
+                             (700.0, 2149.42297742),
+                             (800.0, 3331.605615),
+                             (900.0, 5163.98870326),
+                             (1000.0, 8004.18249005)]},
+         'width': {'initial': 0.0,
+                   'maximum': 1000.0,
+                   'minimum': 0.0,
+                   'name': 'width',
+                   'tag': 'wdth',
+                   'warp': []}}
+
+        >>> doc.process(makeGlyphs=False, makeKerning=False, makeInfo=False)
         """
 
     sys.exit(doctest.testmod().failed)

--- a/Lib/mutatorMath/test/ufo/test.py
+++ b/Lib/mutatorMath/test/ufo/test.py
@@ -349,28 +349,28 @@ if __name__ == "__main__":
 
         >>> doc = DesignSpaceDocumentReader(documentPath, ufoVersion, roundGeometry=roundGeometry, verbose=True, logPath=logPath)
         >>> pprint(doc.axes)
-        {'weight': {'initial': 0.0,
+        {'weight': {'default': 0.0,
+                    'map': [(0.0, 100.0),
+                            (100.0, 155.0),
+                            (200.0, 240.0),
+                            (300.0, 372.0),
+                            (400.0, 577.0),
+                            (500.0, 895.0),
+                            (600.0, 1387.0),
+                            (700.0, 2149.0),
+                            (800.0, 3332.0),
+                            (900.0, 5164.0),
+                            (1000.0, 8004.0)],
                     'maximum': 1000.0,
                     'minimum': -1000.0,
                     'name': 'weight',
-                    'tag': 'wght',
-                    'warp': [(0.0, 100.0),
-                             (100.0, 155.0),
-                             (200.0, 240.0),
-                             (300.0, 372.0),
-                             (400.0, 577.0),
-                             (500.0, 895.0),
-                             (600.0, 1387.0),
-                             (700.0, 2149.0),
-                             (800.0, 3332.0),
-                             (900.0, 5164.0),
-                             (1000.0, 8004.0)]},
-         'width': {'initial': 0.0,
+                    'tag': 'wght'},
+         'width': {'default': 0.0,
+                   'map': [],
                    'maximum': 1000.0,
                    'minimum': 0.0,
                    'name': 'width',
-                   'tag': 'wdth',
-                   'warp': []}}
+                   'tag': 'wdth'}}
 
         >>> doc.process(makeGlyphs=False, makeKerning=False, makeInfo=False)
         """

--- a/Lib/mutatorMath/test/ufo/test.py
+++ b/Lib/mutatorMath/test/ufo/test.py
@@ -342,9 +342,6 @@ if __name__ == "__main__":
 
         >>> # axis with a warp map
         >>> warpMap = grow(100,0.55,11)
-        >>> warpMap
-        [(0, 100.0), (100, 155.0), (200, 240.0), (300, 372.0), (400, 577.0), (500, 895.0), (600, 1387.0), (700, 2149.0), (800, 3332.0), (900, 5164.0), (1000, 8004.0)]
-
         >>> doc.addAxis("wght", "weight", -1000, 1000, 0, warpMap)
         >>> # axis without a warp map
         >>> doc.addAxis("wdth", "width", 0, 1000, 0)

--- a/Lib/mutatorMath/test/ufo/testData/geometryTest.designspace
+++ b/Lib/mutatorMath/test/ufo/testData/geometryTest.designspace
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
+    <axes />
     <sources>
         <source filename="geometryMaster1.ufo" name="master_1">
             <lib copy="1" />

--- a/Lib/mutatorMath/test/ufo/testData/kerningTest.designspace
+++ b/Lib/mutatorMath/test/ufo/testData/kerningTest.designspace
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
+    <axes />
     <sources>
         <source filename="validMaster1.ufo" name="master_1">
             <lib copy="1" />

--- a/Lib/mutatorMath/test/ufo/testData/mutingTest.designspace
+++ b/Lib/mutatorMath/test/ufo/testData/mutingTest.designspace
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
+    <axes />
     <sources>
         <source filename="mutingMaster1.ufo" name="master_1">
             <lib copy="1" />

--- a/Lib/mutatorMath/ufo/document.py
+++ b/Lib/mutatorMath/ufo/document.py
@@ -320,14 +320,14 @@ class DesignSpaceDocumentWriter(object):
             axisElement = ET.Element("axis")
             axisElement.attrib['name'] = name
             for a, b in warpDict[name]:
-                warpPt = ET.Element("point")
+                warpPt = ET.Element("map")
                 warpPt.attrib['input'] = str(a)
                 warpPt.attrib['output'] = str(b)
                 axisElement.append(warpPt)
             warpElement.append(axisElement)
         self.root.append(warpElement)
 
-    def addAxis(self, tag, name, minimum, maximum, initial, warpMap=None):
+    def addAxis(self, tag, name, minimum, maximum, default, warpMap=None):
         """ Write an axis element.
             This will be added to the <axes> element.
          """
@@ -336,10 +336,10 @@ class DesignSpaceDocumentWriter(object):
         axisElement.attrib['tag'] = tag
         axisElement.attrib['minimum'] = str(minimum)
         axisElement.attrib['maximum'] = str(maximum)
-        axisElement.attrib['initial'] = str(initial)
+        axisElement.attrib['default'] = str(default)
         if warpMap is not None:
             for a, b in warpMap:
-                warpPt = ET.Element("point")
+                warpPt = ET.Element("map")
                 warpPt.attrib['input'] = str(a)
                 warpPt.attrib['output'] = str(b)
                 axisElement.append(warpPt)
@@ -452,9 +452,9 @@ class DesignSpaceDocumentReader(object):
         ::
             <warp>
                 <axis name="weight">
-                    <point input="0" output="0" />
-                    <point input="500" output="200" />
-                    <point input="1000" output="1000" />
+                    <map input="0" output="0" />
+                    <map input="500" output="200" />
+                    <map input="1000" output="1000" />
                 </axis>
             </warp>
 
@@ -475,16 +475,18 @@ class DesignSpaceDocumentReader(object):
         for axisElement in self.root.findall(".axes/axis"):
             axis = {}
             axis['name'] = name = axisElement.attrib.get("name")
-            axis['descriptiveName'] = name = axisElement.attrib.get("descriptivename")
             axis['tag'] = axisElement.attrib.get("tag")
             axis['minimum'] = float(axisElement.attrib.get("minimum"))
             axis['maximum'] = float(axisElement.attrib.get("maximum"))
             axis['default'] = float(axisElement.attrib.get("default"))
-            axis['map'] = []       # name is something else?
+            # we're not using the map for anything.
+            axis['map'] = []
             for warpPoint in axisElement.findall(".map"):
                 inputValue = float(warpPoint.attrib.get("input"))
                 outputValue = float(warpPoint.attrib.get("output"))
                 axis['map'].append((inputValue, outputValue))
+            # there are labelnames in the element
+            # but we don't need them for building the fonts.
             self.axes[name] = axis
             self.axesOrder.append(axis['name'])
 

--- a/Lib/mutatorMath/ufo/instance.py
+++ b/Lib/mutatorMath/ufo/instance.py
@@ -35,17 +35,17 @@ class InstanceWriter(object):
     
     def __init__(self, path, ufoVersion=1,
             roundGeometry=False,
-            warpDict=None,
+            axes=None,
             verbose=False,
             logger=None):
         self.path = path
         self.font = self._fontClass()
         self.ufoVersion = ufoVersion
         self.roundGeometry = roundGeometry
-        if warpDict is not None:
-            self.warpDict = warpDict
+        if axes is not None:
+            self.axes = axes
         else:
-            self.warpDict = {}
+            self.axes = {}
         self.sources = {} 
         self.muted = dict(kerning=[], info=[], glyphs={})   # muted data in the masters
         self.mutedGlyphsNames = []                          # muted glyphs in the instance
@@ -195,7 +195,7 @@ class InstanceWriter(object):
                 continue
             items.append((sourceLocation, MathInfo(source.info)))
         try:
-            bias, m = buildMutator(items, warpDict=self.warpDict)
+            bias, m = buildMutator(items, axes=self.axes)
         except:
             self.logger.exception("Error processing font info. %s", items)
             return
@@ -296,7 +296,7 @@ class InstanceWriter(object):
         if items:
             m = None
             try:
-                bias, m = buildMutator(items, warpDict=self.warpDict)
+                bias, m = buildMutator(items, axes=self.axes)
             except:
                 self.logger.exception("Error processing kerning data. %s", items)
                 return
@@ -365,7 +365,7 @@ class InstanceWriter(object):
                 continue
             glyphObject = MathGlyph(fontObject[glyphName])
             items.append((locationObject, glyphObject))
-        bias, m = buildMutator(items, warpDict=self.warpDict)
+        bias, m = buildMutator(items, axes=self.axes)
         instanceObject = m.makeInstance(instanceLocationObject)
         if self.roundGeometry:
             try:


### PR DESCRIPTION
This adds support for axis elements and fixes a bug in `document.py`
* new `axes` top element.
* `warp` element is now part of the `axis` element
* `buildMutator` and `Bender` take axis data rather than warpdict.
* `point` element, child of warp element become `map` element, child of `axis`
* updated some of the tests
* remove a bunch of calls to the logger.
* fixed a bug in `document.py` where the code attempted to use a ufo3 specific attribute even when the sources and the defcon objects are ufo2.