### PR TITLE
Fixes Letterror/MutatorMath#67: test failure in Python 3

### DIFF
--- a/Lib/mutatorMath/objects/location.py
+++ b/Lib/mutatorMath/objects/location.py
@@ -242,8 +242,10 @@ class Location(dict):
         ::
         
             >>> l = Location(pop=1, snap=-100)
-            >>> l.asDict()
-            {'snap': -100, 'pop': 1}
+            >>> l.asDict()['snap']
+            -100
+            >>> l.asDict()['pop']
+            1
         """
         new = {}
         new.update(self)
@@ -254,8 +256,14 @@ class Location(dict):
         ::
 
             >>> l = Location(pop=1, snap=(1,10))
-            >>> l.asSortedStringDict()
-            [{'value': '1', 'axis': 'pop'}, {'value': '(1,10)', 'axis': 'snap'}]
+            >>> l.asSortedStringDict()[0]['value']
+            '1'
+            >>> l.asSortedStringDict()[0]['axis']
+            'pop'
+            >>> l.asSortedStringDict()[1]['axis']
+            'snap'
+            >>> l.asSortedStringDict()[1]['value']
+            '(1,10)'
             
         """
         data = []
@@ -1052,8 +1060,13 @@ if __name__ == "__main__":
         >>> l = [a, b, c, d, e, f]
         >>> test = Location(pop=.5, snap=.5)
         >>> from mutatorMath.objects.mutator import getLimits
-        >>> getLimits(l, test)
-        {'snap': (None, 0.5, None), 'pop': (0.35, None, 1)}
+        >>> limits = getLimits(l, test)
+        >>> 'snap' in limits and 'pop' in limits
+        True
+        >>> limits['snap']
+        (None, 0.5, None)
+        >>> limits['pop']
+        (0.35, None, 1)
 
         # sort a group of locations
         >>> sortLocations(l)

--- a/Lib/mutatorMath/objects/mutator.py
+++ b/Lib/mutatorMath/objects/mutator.py
@@ -133,7 +133,7 @@ class Mutator(dict):
         s = {}
         for l, x in self.items():
             s.update(dict.fromkeys([k for k, v in l], None))
-        return list(s.keys())
+        return s.keys()
 
     def _collectAxisPoints(self):
         """
@@ -583,11 +583,12 @@ if __name__ == "__main__":
         locations = [la, lb]
         test  = Location(pop=t)
         print(getLimits(locations, test))
+
     def test_methods():
         """ Test some of the methods.
         >>> m = test_methods()
-        >>> m.getAxisNames()
-        ['snap', 'pop']
+        >>> sorted(list(m.getAxisNames()))
+        ['pop', 'snap']
         """
         m = Mutator()
         neutral = 0

--- a/Lib/mutatorMath/objects/mutator.py
+++ b/Lib/mutatorMath/objects/mutator.py
@@ -133,7 +133,7 @@ class Mutator(dict):
         s = {}
         for l, x in self.items():
             s.update(dict.fromkeys([k for k, v in l], None))
-        return s.keys()
+        return sorted(list(s.keys()))
 
     def _collectAxisPoints(self):
         """
@@ -587,7 +587,7 @@ if __name__ == "__main__":
     def test_methods():
         """ Test some of the methods.
         >>> m = test_methods()
-        >>> sorted(list(m.getAxisNames()))
+        >>> m.getAxisNames()
         ['pop', 'snap']
         """
         m = Mutator()

--- a/Lib/mutatorMath/objects/mutator.py
+++ b/Lib/mutatorMath/objects/mutator.py
@@ -4,6 +4,7 @@ from mutatorMath.objects.error import MutatorError
 from mutatorMath.objects.location import Location, sortLocations, biasFromLocations
 
 import sys, warnings
+from operator import itemgetter
 
 
 __all__ = ['Mutator', 'buildMutator']
@@ -236,8 +237,7 @@ class Mutator(dict):
             if not (factor-_EPSILON < 0 < factor+_EPSILON) or allFactors:
                 # only add non-zero deltas.
                 deltas.append((factor, mathItem, deltaName))
-        deltas.sort()
-        deltas.reverse()
+        deltas = sorted(deltas, key=itemgetter(0, 1), reverse=True)
         return deltas
 
     #

--- a/Lib/mutatorMath/objects/mutator.py
+++ b/Lib/mutatorMath/objects/mutator.py
@@ -128,12 +128,12 @@ class Mutator(dict):
 
     def getAxisNames(self):
         """
-            Collect a list of axis names from all deltas.
+            Collect a set of axis names from all deltas.
         """
         s = {}
         for l, x in self.items():
             s.update(dict.fromkeys([k for k, v in l], None))
-        return sorted(list(s.keys()))
+        return set(s.keys())
 
     def _collectAxisPoints(self):
         """
@@ -587,7 +587,7 @@ if __name__ == "__main__":
     def test_methods():
         """ Test some of the methods.
         >>> m = test_methods()
-        >>> m.getAxisNames()
+        >>> sorted(list(m.getAxisNames()))
         ['pop', 'snap']
         """
         m = Mutator()


### PR DESCRIPTION
Changes the return type of `mutator.getAxisNames()` from a list to a set, and amends unit tests to not rely on the implicit order of a set converted to a list. See Letterror/MutatorMath#67 for discussion of the original issue. I tested the fix on both Python 2 and Python 3, looks good here.