### PR TITLE
use tox to run the test suite

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,34 @@
+[run]
+# measure 'branch' coverage in addition to 'statement' coverage
+# See: http://coverage.readthedocs.org/en/coverage-4.0.3/branch.html#branch
+branch = True
+
+# list of directories or packages to measure
+source = mutatorMath
+
+# these are treated as equivalent when combining data
+[paths]
+source =
+    Lib/mutatorMath
+    .tox/*/lib/python*/site-packages/mutatorMath
+    .tox/pypy*/site-packages/mutatorMath
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # keywords to use in inline comments to skip coverage
+    pragma: no cover
+
+    # don't complain if tests don't hit defensive assertion code
+    raise AssertionError
+    raise NotImplementedError
+
+    # don't complain if non-runnable code isn't run
+    if 0:
+    if __name__ == .__main__.:
+
+# ignore source code that can’t be found
+ignore_errors = True
+
+# when running a summary report, show missing lines
+show_missing = True

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ __pycache__/
 build
 dist
 
+# Unit test / coverage files
+.tox/
+.coverage
+.coverage.*
+htmlcov/
+
 Lib/support/axes.py
 
 Lib/support/mutatorMath-A.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,27 @@
-language: python
 sudo: false
-python:
-  - "2.7"
-  - "3.5"
+
+language: python
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27-cov
+    - python: 3.5
+      env: TOXENV=py35-cov
+    - python: 3.6
+      env: TOXENV=py36-cov
+
 install:
-  - pip install -r requirements.txt
+  - pip install tox
   - pip install coveralls
+
 script:
-  - coverage run --parallel-mode --source=mutatorMath setup.py test
+  - tox
+
 after_success:
   - coverage combine
   - coveralls
+
 deploy:
   # deploy to PyPI on tags
   provider: pypi

--- a/Lib/mutatorMath/objects/location.py
+++ b/Lib/mutatorMath/objects/location.py
@@ -751,4 +751,4 @@ def mostCommon(L):
 
 if __name__ == "__main__":
     import doctest
-    doctest.testmod()
+    sys.exit(doctest.testmod().failed)

--- a/Lib/mutatorMath/objects/mutator.py
+++ b/Lib/mutatorMath/objects/mutator.py
@@ -455,5 +455,4 @@ def getLimits(locations, current, sortResults=True, verbose=False):
 
 if __name__ == "__main__":
     import doctest
-    doctest.testmod()
-
+    sys.exit(doctest.testmod().failed)

--- a/Lib/mutatorMath/test/objects/location.py
+++ b/Lib/mutatorMath/test/objects/location.py
@@ -534,5 +534,6 @@ def regressionTests():
 
 
 if __name__ == '__main__':
+    import sys
     import doctest
-    doctest.testmod()
+    sys.exit(doctest.testmod().failed)

--- a/Lib/mutatorMath/test/objects/mutator.py
+++ b/Lib/mutatorMath/test/objects/mutator.py
@@ -245,5 +245,6 @@ def test_builderBender_2():
 
 
 if __name__ == "__main__":
+    import sys
     import doctest
-    doctest.testmod()
+    sys.exit(doctest.testmod().failed)

--- a/Lib/mutatorMath/test/run.py
+++ b/Lib/mutatorMath/test/run.py
@@ -29,5 +29,4 @@ def load_tests(loader, tests, ignore):
 
 
 if __name__ == '__main__':
-    unittest.main()
-
+    sys.exit(unittest.main())

--- a/Lib/mutatorMath/test/run.py
+++ b/Lib/mutatorMath/test/run.py
@@ -1,13 +1,34 @@
+import os
+import sys
 import unittest
 import doctest
 
+# The 'mutatorMath.test' sub-package is not installed along with the others.
+# But we need it to be importable so we can use it in setup.py 'test_suite'.
+# We would also like to run the test suite against an installed version of
+# mutatorMath package, and not just against the Lib/mutatorMath source
+# directory, in order to catch issues with packaging.
+# Therefore, below we first import mutatorMath, so whatever 'mutatorMath' is
+# first found on the PYTHONPATH will be loaded in sys.modules.
+# Then, we temporarily extend the PYTHONPATH to include the location of the
+# 'mutatorMath.test' sub-package, relative to the current 'run.py' script.
+# This way we can import the doctest modules without also attempting to
+# import the 'mutatorMath.test' sub-package, which may be missing when we
+# testing an installed mutatorMath, vs the 'editable' Lib/mutatorMath.
+
 import mutatorMath
-import mutatorMath.test.objects.mutator
-import mutatorMath.test.objects.location
-import mutatorMath.test.ufo.test
-import mutatorMath.test.ufo.geometryTest
-import mutatorMath.test.ufo.kerningTest
-import mutatorMath.test.ufo.mutingTest
+
+HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, HERE)
+try:
+    import test.objects.mutator
+    import test.objects.location
+    import test.ufo.test
+    import test.ufo.geometryTest
+    import test.ufo.kerningTest
+    import test.ufo.mutingTest
+finally:
+    sys.path.remove(HERE)
 
 
 def load_tests(loader, tests, ignore):
@@ -16,14 +37,14 @@ def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(mutatorMath.objects.mutator))
 
     # standalone Location and Mutator doctests
-    tests.addTests(doctest.DocTestSuite(mutatorMath.test.objects.mutator))
-    tests.addTests(doctest.DocTestSuite(mutatorMath.test.objects.location))
+    tests.addTests(doctest.DocTestSuite(test.objects.mutator))
+    tests.addTests(doctest.DocTestSuite(test.objects.location))
 
     # doctests in the test.ufo package
-    tests.addTests(doctest.DocTestSuite(mutatorMath.test.ufo.test))
-    tests.addTests(doctest.DocTestSuite(mutatorMath.test.ufo.geometryTest))
-    tests.addTests(doctest.DocTestSuite(mutatorMath.test.ufo.kerningTest))
-    tests.addTests(doctest.DocTestSuite(mutatorMath.test.ufo.mutingTest))
+    tests.addTests(doctest.DocTestSuite(test.ufo.test))
+    tests.addTests(doctest.DocTestSuite(test.ufo.geometryTest))
+    tests.addTests(doctest.DocTestSuite(test.ufo.kerningTest))
+    tests.addTests(doctest.DocTestSuite(test.ufo.mutingTest))
 
     return tests
 

--- a/Lib/mutatorMath/test/ufo/geometryTest.py
+++ b/Lib/mutatorMath/test/ufo/geometryTest.py
@@ -145,4 +145,4 @@ def test1():
 
 if __name__ == "__main__":
     import doctest
-    doctest.testmod()
+    sys.exit(doctest.testmod().failed)

--- a/Lib/mutatorMath/test/ufo/kerningTest.py
+++ b/Lib/mutatorMath/test/ufo/kerningTest.py
@@ -138,4 +138,4 @@ def testOuroborosKerning(rootPath, cleanUp=True):
 
 if __name__ == "__main__":
     import doctest
-    doctest.testmod()
+    sys.exit(doctest.testmod().failed)

--- a/Lib/mutatorMath/test/ufo/mutingTest.py
+++ b/Lib/mutatorMath/test/ufo/mutingTest.py
@@ -141,4 +141,4 @@ def test1():
 
 if __name__ == "__main__":
     import doctest
-    doctest.testmod()
+    sys.exit(doctest.testmod().failed)

--- a/Lib/mutatorMath/test/ufo/test.py
+++ b/Lib/mutatorMath/test/ufo/test.py
@@ -295,7 +295,7 @@ def test1():
     >>> documentPath = os.path.join(testRoot, 'warpmap_test.designspace')
     >>> doc = DesignSpaceDocumentWriter(documentPath, verbose=True)
     >>> def grow(base, factor, steps):
-    ...     return [(i*100, round(base*(1+factor)**i)) for i in range(steps)]
+    ...     return [(i*100, int(round(base*(1+factor)**i))) for i in range(steps)]
     >>> doc.addAxis("wght", "weight", 0, 1000, 0, grow(100,0.55,11))
     >>> doc.addSource(
     ...        os.path.join(sourcePath, "stems", "StemThin.ufo"),
@@ -380,7 +380,7 @@ def test1():
     >>> documentPath = os.path.join(testRoot, 'axes_test.designspace')
     >>> doc = DesignSpaceDocumentWriter(documentPath, verbose=True)
     >>> def grow(base, factor, steps):
-    ...     return [(i*100, round(base*(1+factor)**i)) for i in range(steps)]
+    ...     return [(i*100, int(round(base*(1+factor)**i))) for i in range(steps)]
 
     >>> # axis with a warp map
     >>> warpMap = grow(100,0.55,11)

--- a/Lib/mutatorMath/test/ufo/test.py
+++ b/Lib/mutatorMath/test/ufo/test.py
@@ -471,5 +471,6 @@ def bender_and_mutatorTest():
     """
 
 if __name__ == '__main__':
+    import sys
     import doctest
-    doctest.testmod()
+    sys.exit(doctest.testmod().failed)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-fonttools==3.6.2
 ufoLib==2.0.0
 defcon==0.2.1
 fontMath==0.4.2

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys
-from setuptools import setup, Command
+from setuptools import setup, Command, find_packages
 from distutils import log
 import contextlib
 
@@ -189,11 +189,7 @@ setup(
     author_email="erik@letterror.com",
     url="https://github.com/LettError/MutatorMath",
     license="BSD 3 Clause",
-    packages=[
-        "mutatorMath",
-        "mutatorMath.objects",
-        "mutatorMath.ufo",
-    ],
+    packages=find_packages("Lib", exclude=['*.test', '*.test.*']),
     package_dir={"": "Lib"},
     setup_requires=[
         'bumpversion',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,40 @@
+[tox]
+envlist = py{27,36}-cov, htmlcov
+
+[testenv]
+# The TOXPYTHON environment variable is only used for selecting the base
+# python interpreter on Appveyor, as Windows Python is just 'python.exe'
+basepython =
+    py27: {env:TOXPYTHON:python2.7}
+    py35: {env:TOXPYTHON:python3.5}
+    py36: {env:TOXPYTHON:python3.6}
+# If the tox env name contains '-cov', we install from the sdist and run the
+# test suite against the installed package:
+#   $ tox -e py27-cov
+# If it contains '-dev' we skip the sdist and install in 'editable' mode:
+#   $ tox -e py27-dev
+usedevelop =
+    cov: false
+    dev: true
+deps =
+    -rrequirements.txt
+    cov: coverage
+# If the tox env name contains "-cov", we run the test suite through the
+# "coverage" tool to collect test coverage data.
+# If it's "-dev", we don't collect test coverage data, which should be a
+# bit quicker.
+# The {posargs} are positional arguments passed to the 'tox' script after the
+# '--' separator. E.g. you can use them to run a specific test module in tox:
+#   $ tox -- Lib/mutatorMath/test/ufo/kerningTest.py
+# With no {posargs}, tox will run the whole test suite in verbose mode.
+commands =
+    cov: coverage run --parallel-mode {posargs:Lib/mutatorMath/test/run.py -v}
+    dev: python {posargs:Lib/mutatorMath/test/run.py -v}
+
+[testenv:htmlcov]
+basepython = {env:TOXPYTHON:python}
+deps = coverage
+skip_install = true
+commands =
+    coverage combine
+    coverage html


### PR DESCRIPTION
We use [`tox`](http://tox.readthedocs.io/) for all the other fonttools open source projects.
It makes it easier to run the test suite on different python versions, both locally and remotely on the CI.

The basic usage, if you want to run the tests locally the same way that Travis would do, is:

1) Ensure both `python2.7` and `python3.6` are available on your `$PATH`.

2) install `tox` as usual:
```sh
$ pip install tox
```

3) run the test suite on both python2.7 and 3.6 in isolated virtual environments:
```sh
$ tox
```

The command also generates an HTML page with the combined test coverage at `htmlcov/index.html`.

You can also tell `tox` to only run a specific environment by passing `-e` option, or by setting the `$TOXENV` environment variable (as we do on Travis CI).

Read individual commit messages for more info.