### PR TITLE
This addresses a problem caused by files in which a source element ha…

### DIFF
--- a/Lib/mutatorMath/ufo/document.py
+++ b/Lib/mutatorMath/ufo/document.py
@@ -502,8 +502,7 @@ class DesignSpaceDocumentReader(object):
             </source>
 
         """
-        sourceCount = 0
-        for sourceElement in self.root.findall(".sources/source"):
+        for sourceCount, sourceElement in enumerate(self.root.findall(".sources/source")):
             # shall we just read the UFO here?
             filename = sourceElement.attrib.get('filename')
             # filename is a path relaive to the documentpath. resolve first.
@@ -512,9 +511,8 @@ class DesignSpaceDocumentReader(object):
             if sourceName is None:
                 # if the source element has no name attribute
                 # (some authoring tools do not need them)
-                # then we should make a temporary one
+                # then we should make a temporary one. We still need it for reference.
                 sourceName = "temp_master.%d"%(sourceCount)
-                print("created temp source name", sourceName)
             self.reportProgress("prep", 'load', sourcePath)
             if not os.path.exists(sourcePath):
                 raise MutatorError("Source not found at %s"%sourcePath)
@@ -568,7 +566,6 @@ class DesignSpaceDocumentReader(object):
             # store
             self.sources[sourceName] = sourceObject, sourceLocationObject
             self.reportProgress("prep", 'done')
-            sourceCount+=1
 
     def locationFromElement(self, element):
         """

--- a/Lib/mutatorMath/ufo/document.py
+++ b/Lib/mutatorMath/ufo/document.py
@@ -502,12 +502,19 @@ class DesignSpaceDocumentReader(object):
             </source>
 
         """
+        sourceCount = 0
         for sourceElement in self.root.findall(".sources/source"):
             # shall we just read the UFO here?
             filename = sourceElement.attrib.get('filename')
             # filename is a path relaive to the documentpath. resolve first.
             sourcePath = os.path.abspath(os.path.join(os.path.dirname(self.path), filename))
             sourceName = sourceElement.attrib.get('name')
+            if sourceName is None:
+                # if the source element has no name attribute
+                # (some authoring tools do not need them)
+                # then we should make a temporary one
+                sourceName = "temp_master.%d"%(sourceCount)
+                print("created temp source name", sourceName)
             self.reportProgress("prep", 'load', sourcePath)
             if not os.path.exists(sourcePath):
                 raise MutatorError("Source not found at %s"%sourcePath)
@@ -561,6 +568,7 @@ class DesignSpaceDocumentReader(object):
             # store
             self.sources[sourceName] = sourceObject, sourceLocationObject
             self.reportProgress("prep", 'done')
+            sourceCount+=1
 
     def locationFromElement(self, element):
         """


### PR DESCRIPTION
…s no name attribute. Mutator uses the value of the name attribute to store some data and retrieve it later. This adds a temporary simple unique name.