### PR TITLE
MathKerning needs groups.

### DIFF
--- a/Lib/mutatorMath/ufo/instance.py
+++ b/Lib/mutatorMath/ufo/instance.py
@@ -271,7 +271,7 @@ class InstanceWriter(object):
             if copy:
                 value = getattr(sourceInfo, infoAttribute)
                 setattr(targetInfo, infoAttribute, value)
-        
+
     def addKerning(self, instanceLocation=None, sources=None):
         """
         Calculate the kerning data for this location and add it to this instance.
@@ -295,8 +295,7 @@ class InstanceWriter(object):
                     self.logger.info("\tMuting kerning data for %s", instanceLocation)
                 continue
             if len(source.kerning.keys())>0:
-                items.append((sourceLocation, MathKerning(source.kerning)))
-        # items.sort()
+                items.append((sourceLocation, MathKerning(source.kerning, source.groups)))
         if items:
             m = None
             try:


### PR DESCRIPTION
The MathKerning object needs the groups in order to be able to identify the exceptions.