### PR TITLE
Allow to read new format="4.0" as a float

### DIFF
--- a/Lib/mutatorMath/ufo/document.py
+++ b/Lib/mutatorMath/ufo/document.py
@@ -402,7 +402,7 @@ class DesignSpaceDocumentReader(object):
         tree = ET.parse(self.path)
         self.root = tree.getroot()
         self.readVersion()
-        assert self.documentFormatVersion == 3
+        assert self.documentFormatVersion >= 3
 
         self.readAxes()
         self.readWarp()
@@ -447,7 +447,12 @@ class DesignSpaceDocumentReader(object):
             <designspace format="3">
         """
         ds = self.root.findall("[@format]")[0]
-        self.documentFormatVersion = int(ds.attrib['format'])
+        raw_format = ds.attrib['format']
+        try:
+            self.documentFormatVersion = int(raw_format)
+        except ValueError:
+            # as of fontTools >= 3.27 'format' is formatted as a float "4.0"
+            self.documentFormatVersion = float(raw_format)
 
     def readWarp(self):
         """ Read the warp element


### PR DESCRIPTION
In https://github.com/fonttools/fonttools/commit/ceb41ec484b3aed5127962a3e2c2030a56d704e1 (still unreleased), @LettError changed the designspace document "format" field from an integer "3" to a float "4.0". 

Using mutatorMath DesignSpaceDocumentReader with a designspace file that was generated by the new fontTools.designspaceLib (with format "4.0"), currently throws a ValueError.
GlyphsLib uses fonttools.designspaceLib to create designspace documents, and fontmake (still) uses mutatorMath for instantiating UFOs. 

I undersand we want to move away from relying on mutatorMath's own UFO processing (#113) in favour of ufoProcessor. However, we need some time before we can update fontmake to use that. And before then we need to be able to release the new fonttools without breaking fontmake because of mutatorMath..

This patch allows to read in a 4.0 designspace document without the error. Note that the only new feature added to 4.0 is the conditionset elements in the rules, but mutatorMath itself does not read the rules elements, so this change should be innocuous.

PTAL, thanks.